### PR TITLE
disable menu items

### DIFF
--- a/frontend/config-assistant/src/components/toolbar/TopMenuBar.ts
+++ b/frontend/config-assistant/src/components/toolbar/TopMenuBar.ts
@@ -8,8 +8,8 @@ import {generateSampleData} from '@/components/toolbar/createSampleData';
 import {ChangeResponsible, useSessionStore} from '@/store/sessionStore';
 import {errorService} from '@/main';
 import {ref} from 'vue';
-import type {MenuItemCommandEvent} from 'primevue/menuitem';
 import {clearSchemaEditor} from '@/components/toolbar/clearSchema';
+import {storeToRefs} from 'pinia';
 
 /**
  * Helper class that contains the menu items for the top menu bar.
@@ -90,6 +90,8 @@ export class TopMenuBar {
       {
         label: 'Undo',
         icon: 'fa-solid fa-rotate-left',
+        disabled: () => !storeToRefs(useSessionStore()).currentEditorWrapper.value.hasUndo(),
+        key: 'undo',
         command: () => {
           this.sessionStore.currentEditorWrapper.undo();
         },
@@ -100,6 +102,8 @@ export class TopMenuBar {
         command: () => {
           this.sessionStore.currentEditorWrapper.redo();
         },
+        key: 'redo',
+        disabled: () => !useSessionStore().currentEditorWrapper.hasRedo(),
       },
       {
         separator: true,
@@ -108,6 +112,7 @@ export class TopMenuBar {
         label: 'Share',
         class: 'z-10',
         icon: 'fa-solid fa-share-nodes',
+        disabled: true,
       },
     ];
   }
@@ -129,6 +134,7 @@ export class TopMenuBar {
             command: () => {
               throw new Error('Not implemented yet');
             },
+            disabled: true,
           },
         ],
       },
@@ -153,6 +159,7 @@ export class TopMenuBar {
             command: () => {
               throw new Error('Not implemented yet');
             },
+            disabled: true,
           },
           {
             label: 'Example Schemas',
@@ -175,6 +182,8 @@ export class TopMenuBar {
         command: () => {
           this.sessionStore.currentEditorWrapper.undo();
         },
+        disabled: () => !useSessionStore().currentEditorWrapper.hasUndo(),
+        key: 'schema_undo',
       },
       {
         label: 'Redo',
@@ -182,6 +191,8 @@ export class TopMenuBar {
         command: () => {
           this.sessionStore.currentEditorWrapper.redo();
         },
+        disabled: () => !useSessionStore().currentEditorWrapper.hasRedo(),
+        key: 'schema_redo',
       },
       {
         separator: true,
@@ -190,6 +201,7 @@ export class TopMenuBar {
         label: 'Share',
         class: 'z-10',
         icon: 'fa-solid fa-share-nodes',
+        disabled: true,
       },
     ];
   }
@@ -202,6 +214,7 @@ export class TopMenuBar {
         command: () => {
           throw new Error('Not implemented yet');
         },
+        disabled: true,
       },
       {
         label: 'Save settings file',
@@ -217,6 +230,8 @@ export class TopMenuBar {
         command: () => {
           this.sessionStore.currentEditorWrapper.undo();
         },
+        disabled: () => !useSessionStore().currentEditorWrapper.hasUndo(),
+        key: 'settings_undo',
       },
       {
         label: 'Redo',
@@ -224,6 +239,8 @@ export class TopMenuBar {
         command: () => {
           this.sessionStore.currentEditorWrapper.redo();
         },
+        disabled: () => !useSessionStore().currentEditorWrapper.hasRedo(),
+        key: 'settings_redo',
       },
       {
         separator: true,
@@ -232,6 +249,7 @@ export class TopMenuBar {
         label: 'Share',
         class: 'z-10',
         icon: 'fa-solid fa-share-nodes',
+        disabled: true,
       },
     ];
   }

--- a/frontend/config-assistant/src/components/toolbar/TopToolbar.vue
+++ b/frontend/config-assistant/src/components/toolbar/TopToolbar.vue
@@ -4,7 +4,7 @@ import type {MenuItem} from 'primevue/menuitem';
 import Menu from 'primevue/menu';
 import Toolbar from 'primevue/toolbar';
 import {TopMenuBar} from '@/components/toolbar/TopMenuBar';
-import {SessionMode} from '@/store/sessionStore';
+import {SessionMode, useSessionStore} from '@/store/sessionStore';
 import SchemaEditorView from '@/views/SchemaEditorView.vue';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
@@ -14,12 +14,13 @@ import {useToast} from 'primevue/usetoast';
 import {JsonSchema} from '@/helpers/schema/JsonSchema';
 import {
   clearEditor,
-  showConfirmation,
   confirmationDialogMessage,
   newEmptyFile,
+  showConfirmation,
 } from '@/components/toolbar/clearContent';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 import {errorService} from '@/main';
+import {storeToRefs} from 'pinia';
 
 const props = defineProps<{
   currentMode: SessionMode;
@@ -194,6 +195,32 @@ function getLabelOfItem(item: MenuItem): string {
   }
   return item.label();
 }
+
+function isDisabled(item: MenuItem) {
+  if (!item.disabled) {
+    return false;
+  }
+  if (typeof item.disabled === 'boolean') {
+    return item.disabled;
+  }
+  return item.disabled();
+}
+
+// apparently, the primevue button cannot reactively update its disabled state
+// so this is a workaround to change the disabled state of the button
+watch(storeToRefs(useSessionStore()).fileData, () => {
+  for (const item of getMenuItems()) {
+    if (item.key) {
+      if (isDisabled(item)) {
+        document.getElementById(item.key)?.setAttribute('disabled', '');
+        document.getElementById(item.key)?.classList.add('p-disabled');
+      } else {
+        document.getElementById(item.key)?.removeAttribute('disabled');
+        document.getElementById(item.key)?.classList.remove('p-disabled');
+      }
+    }
+  }
+});
 </script>
 
 <template>
@@ -245,6 +272,8 @@ function getLabelOfItem(item: MenuItem): string {
           class="toolbar-button"
           size="small"
           v-tooltip.bottom="item.label"
+          :id="item.key ?? ''"
+          :disabled="isDisabled(item)"
           @click="event => handleItemButtonClick(item, event)">
           <FontAwesomeIcon :icon="item.icon!!" />
         </Button>


### PR DESCRIPTION
I found a way to disable the menu items. Sadly, the primevue buttons didn't change reactivly, so I had to make an ugly workaround.