### PR TITLE
add about dialog

### DIFF
--- a/frontend/config-assistant/src/components/dialogs/AboutDialog.vue
+++ b/frontend/config-assistant/src/components/dialogs/AboutDialog.vue
@@ -1,0 +1,53 @@
+<!--
+Dialog that shows information about the application and the licenses of the used icons.
+Emits an update:visible event when the dialog is closed.
+-->
+<script setup lang="ts">
+import Dialog from 'primevue/dialog';
+import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+
+defineProps<{visible: boolean}>();
+
+defineEmits<{
+  (e: 'update:visible', newValue: boolean): void;
+}>();
+</script>
+
+<template>
+  <Dialog
+    header="About"
+    :visible="visible"
+    @update:visible="newValue => $emit('update:visible', newValue)">
+    <p>
+      Config Assistant is a tool to help you create and edit configuration files for your
+      applications.
+    </p>
+    <p>It is currently in alpha stage, so expect bugs and missing features.</p>
+    <p>Config Assistant is open source and licensed under the MIT license.</p>
+    <p>
+      Check our
+      <a
+        class="underline text-violet-950"
+        href="https://github.com/PaulBredl/config-assistant"
+        target="_blank"
+        rel="noopener noreferrer">
+        <span class="pi pi-github mr-1" />GitHub
+      </a>
+      for more information
+    </p>
+    <hr class="my-2" />
+    <p>Icons by FontAwesome <FontAwesomeIcon icon="fa-solid fa-font-awesome" /></p>
+    <p>
+      Licensed under
+      <a class="underline text-violet-950" href="https://fontawesome.com/license/free">CC BY 4.0</a>
+    </p>
+    <hr class="my-2" />
+    <p>Icons by PrimeIcons <span class="pi pi-prime mr-1" /></p>
+    <p>
+      Licensed under
+      <a class="underline text-violet-950" href="https://www.primefaces.org/licenses/">MIT</a>
+    </p>
+  </Dialog>
+</template>
+
+<style scoped></style>

--- a/frontend/config-assistant/src/components/toolbar/TopToolbar.vue
+++ b/frontend/config-assistant/src/components/toolbar/TopToolbar.vue
@@ -21,6 +21,7 @@ import {
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 import {errorService} from '@/main';
 import {storeToRefs} from 'pinia';
+import AboutDialog from '@/components/dialogs/AboutDialog.vue';
 
 const props = defineProps<{
   currentMode: SessionMode;
@@ -39,6 +40,8 @@ const selectedSchema = ref<{
 }>(null);
 
 const showFetchedSchemas = ref(false);
+
+const showAboutDialog = ref(false);
 
 function getPageName(): string {
   switch (props.currentMode) {
@@ -248,6 +251,10 @@ watch(storeToRefs(useSessionStore()).fileData, () => {
     <Button label="No" @click="handleReject" class="dialog-button" />
   </Dialog>
 
+  <AboutDialog
+    :visible="showAboutDialog"
+    @update:visible="newValue => (showAboutDialog = newValue)" />
+
   <Toolbar class="h-10 no-padding">
     <template #start>
       <Menu ref="menu" :model="items" :popup="true">
@@ -295,18 +302,28 @@ watch(storeToRefs(useSessionStore()).fileData, () => {
       </div>
     </template>
     <template #end>
-      <div class="flex space-x-10 mr-3">
+      <div class="flex space-x-5 mr-3">
         <div class="flex space-x-2">
           <span class="pi pi-sitemap" style="font-size: 1.7rem" />
           <p class="font-semibold text-lg">ConfigAssistant</p>
         </div>
+
+        <Button
+          circular
+          text
+          class="toolbar-button"
+          size="small"
+          v-tooltip.bottom="'About'"
+          @click="() => (showAboutDialog = true)">
+          <FontAwesomeIcon icon="fa-solid fa-circle-info" />
+        </Button>
 
         <!-- link to our github, opens in a new tab -->
         <a
           href="https://github.com/PaulBredl/config-assistant"
           target="_blank"
           rel="noopener noreferrer"
-          class="pi pi-github hover:scale-110"
+          class="pi pi-github hover:scale-110 text-gray-600"
           style="font-size: 1.7rem" />
       </div>
     </template>

--- a/frontend/config-assistant/src/fontawesome.ts
+++ b/frontend/config-assistant/src/fontawesome.ts
@@ -4,11 +4,13 @@ import {library} from '@fortawesome/fontawesome-svg-core';
 /* import specific icons */
 import {
   faBars,
+  faCircleInfo,
   faCog,
   faDatabase,
   faFileCirclePlus,
   faFloppyDisk,
   faFolderOpen,
+  faFontAwesome,
   faGears,
   faGlobe,
   faMagicWandSparkles,
@@ -40,4 +42,6 @@ export function registerIcons() {
   library.add(faMagicWandSparkles);
   library.add(faFileCode);
   library.add(faCog);
+  library.add(faCircleInfo);
+  library.add(faFontAwesome);
 }


### PR DESCRIPTION
Adds a dialog with license information of our icons

![image](https://github.com/PaulBredl/config-assistant/assets/34026908/f5c457c4-a19b-4630-b4a1-3cc4458fe1a8)
