### PR TITLE
fix and improve selection update when clicking GUI

### DIFF
--- a/frontend/config-assistant/src/components/gui-editor/GuiEditorPanelJsonSchema.vue
+++ b/frontend/config-assistant/src/components/gui-editor/GuiEditorPanelJsonSchema.vue
@@ -29,14 +29,17 @@ function updatePath(newPath: Path) {
 function updateData(path: Path, newValue: any) {
   sessionStore.lastChangeResponsible = ChangeResponsible.GuiEditor;
   sessionStore.updateDataAtPath(path, newValue);
-  sessionStore.lastChangeResponsible = ChangeResponsible.GuiEditor;
-  sessionStore.currentSelectedElement = path;
 }
 
 function zoomIntoPath(pathToAdd: Path) {
   sessionStore.lastChangeResponsible = ChangeResponsible.GuiEditor;
   sessionStore.currentPath = sessionStore.currentPath.concat(pathToAdd);
   sessionStore.currentSelectedElement = sessionStore.currentPath;
+}
+
+function selectPath(path: Path) {
+  sessionStore.lastChangeResponsible = ChangeResponsible.GuiEditor;
+  sessionStore.currentSelectedElement = path;
 }
 </script>
 
@@ -53,6 +56,7 @@ function zoomIntoPath(pathToAdd: Path) {
         :current-path="sessionStore.currentPath"
         :current-data="sessionStore.dataAtCurrentPath"
         @zoom_into_path="pathToAdd => zoomIntoPath(pathToAdd)"
+        @select_path="selectedPath => selectPath(selectedPath)"
         @update_data="updateData" />
     </div>
   </div>

--- a/frontend/config-assistant/src/components/gui-editor/PropertiesPanel.vue
+++ b/frontend/config-assistant/src/components/gui-editor/PropertiesPanel.vue
@@ -29,6 +29,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update_current_path', new_path: Path): void;
   (e: 'zoom_into_path', path_to_add: Path): void;
+  (e: 'select_path', path: Path): void;
   (e: 'update_data', path: Path, newValue: any): void;
 }>();
 
@@ -97,6 +98,12 @@ watch(storeToRefs(useSessionStore()).fileData, (value, oldValue) => {
 function updateData(subPath: Path, newValue: any) {
   const completePath = props.currentPath.concat(subPath);
   emit('update_data', completePath, newValue);
+}
+function clickedPropertyData(nodeData: ConfigTreeNodeData) {
+  const path = nodeData.absolutePath;
+  if (useSessionStore().dataAtPath(path) != undefined) {
+    emit('select_path', path);
+  }
 }
 
 function replacePropertyName(parentPath: Path, oldName: string, newName: string, oldData) {
@@ -366,6 +373,7 @@ function closeInfoOverlayPanel() {
             :nodeData="slotProps.node.data"
             @update_property_value="updateData"
             @update_tree="updateTree"
+            @click="() => clickedPropertyData(slotProps.node.data)"
             bodyClass="w-full"
             @keydown.ctrl.i="event => showInfoOverlayPanelInstantly(slotProps.node.data, event)" />
         </span>


### PR DESCRIPTION
This PR makes it work that when a GUI element is clicked the corresponding entry is selected in code editor.

In another PR I will address the other direction: that selection in code editor leads to selection in GUI Editor.