### PR TITLE
remove min/max property of Integer/Number

### DIFF
--- a/frontend/config-assistant/src/components/gui-editor/properties/IntegerProperty.vue
+++ b/frontend/config-assistant/src/components/gui-editor/properties/IntegerProperty.vue
@@ -11,26 +11,6 @@ const props = defineProps<{
   propertySchema: JsonSchema;
 }>();
 
-const minValue = computed(() => {
-  if (props.propertySchema.exclusiveMinimum !== undefined) {
-    return props.propertySchema.exclusiveMinimum + 1;
-  } else if (props.propertySchema.minimum !== undefined) {
-    return props.propertySchema.minimum;
-  } else {
-    return undefined;
-  }
-});
-
-const maxValue = computed(() => {
-  if (props.propertySchema.exclusiveMaximum !== undefined) {
-    return props.propertySchema.exclusiveMaximum - 1;
-  } else if (props.propertySchema.maximum !== undefined) {
-    return props.propertySchema.maximum;
-  } else {
-    return undefined;
-  }
-});
-
 const emit = defineEmits<{
   (e: 'update_property_value', newValue: number): void;
 }>();
@@ -59,8 +39,6 @@ const valueProperty = computed({
     buttonLayout="stacked"
     :placeholder="generatePlaceholderText(props.propertySchema, props.propertyName)"
     :step="1"
-    :min="minValue"
-    :max="maxValue"
     increment-button-class="p-button-text p-button-secondary"
     decrement-button-class="p-button-text p-button-secondary" />
 </template>

--- a/frontend/config-assistant/src/components/gui-editor/properties/NumberProperty.vue
+++ b/frontend/config-assistant/src/components/gui-editor/properties/NumberProperty.vue
@@ -15,26 +15,6 @@ const stepValue = computed(() => {
   return props.propertySchema.multipleOf ?? 0.1;
 });
 
-const maxValue = computed(() => {
-  if (props.propertySchema.exclusiveMaximum !== undefined) {
-    return props.propertySchema.exclusiveMaximum - stepValue.value;
-  } else if (props.propertySchema.maximum !== undefined) {
-    return props.propertySchema.maximum;
-  } else {
-    return undefined;
-  }
-});
-
-const minValue = computed(() => {
-  if (props.propertySchema.exclusiveMinimum !== undefined) {
-    return props.propertySchema.exclusiveMinimum + stepValue.value;
-  } else if (props.propertySchema.minimum !== undefined) {
-    return props.propertySchema.minimum;
-  } else {
-    return undefined;
-  }
-});
-
 const emit = defineEmits<{
   (e: 'update_property_value', newValue: number | undefined): void;
 }>();
@@ -64,8 +44,6 @@ const valueProperty = computed({
     buttonLayout="stacked"
     :placeholder="generatePlaceholderText(props.propertySchema, props.propertyName)"
     :step="stepValue"
-    :min="minValue"
-    :max="maxValue"
     increment-button-class="p-button-text p-button-secondary"
     decrement-button-class="p-button-text p-button-secondary" />
 </template>


### PR DESCRIPTION
Temporarily removed the max/min from Integer and Number Property.
But how do we do with the error handling?
If an user typed unvalid number against json schema, schema validation should work and show some error right?