### PR TITLE
schema preprocessing: convert types to OneOf

### DIFF
--- a/frontend/config-assistant/resources/json-schema/simplifiedMetaSchema.ts
+++ b/frontend/config-assistant/resources/json-schema/simplifiedMetaSchema.ts
@@ -12,9 +12,6 @@ export const simplifiedMetaSchema = {
         {
           $ref: '#/$defs/objectProperty',
         },
-        {
-          type: ['object'],
-        },
       ],
     },
     jsonSchema: {

--- a/frontend/config-assistant/resources/json-schema/simplifiedMetaSchema.ts
+++ b/frontend/config-assistant/resources/json-schema/simplifiedMetaSchema.ts
@@ -17,10 +17,6 @@ export const simplifiedMetaSchema = {
     jsonSchema: {
       anyOf: [
         {
-          title: 'True or false',
-          type: 'boolean',
-        },
-        {
           $ref: '#/$defs/booleanProperty',
         },
         {
@@ -51,7 +47,7 @@ export const simplifiedMetaSchema = {
           $ref: '#/$defs/refProperty',
         },
       ],
-      type: ['object', 'boolean'],
+      type: ['object'],
       $comment:
         'This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.',
     },
@@ -129,7 +125,7 @@ export const simplifiedMetaSchema = {
     },
     core: {
       title: 'Core vocabulary meta-schema',
-      type: ['object', 'boolean'],
+      type: ['object'],
       properties: {
         $id: {
           $ref: '#/$defs/uriReferenceString',
@@ -353,7 +349,7 @@ export const simplifiedMetaSchema = {
       },
     },
     'meta-data': {
-      type: ['object', 'boolean'],
+      type: ['object'],
       properties: {
         title: {
           type: 'string',

--- a/frontend/config-assistant/resources/json-schema/simplifiedMetaSchema.ts
+++ b/frontend/config-assistant/resources/json-schema/simplifiedMetaSchema.ts
@@ -12,10 +12,17 @@ export const simplifiedMetaSchema = {
         {
           $ref: '#/$defs/objectProperty',
         },
+        {
+          type: ['object'],
+        },
       ],
     },
     jsonSchema: {
       anyOf: [
+        {
+          title: 'True or false',
+          type: 'boolean',
+        },
         {
           $ref: '#/$defs/booleanProperty',
         },
@@ -47,7 +54,7 @@ export const simplifiedMetaSchema = {
           $ref: '#/$defs/refProperty',
         },
       ],
-      type: ['object'],
+      type: ['object', 'boolean'],
       $comment:
         'This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.',
     },
@@ -125,7 +132,7 @@ export const simplifiedMetaSchema = {
     },
     core: {
       title: 'Core vocabulary meta-schema',
-      type: ['object'],
+      type: ['object', 'boolean'],
       properties: {
         $id: {
           $ref: '#/$defs/uriReferenceString',
@@ -349,7 +356,7 @@ export const simplifiedMetaSchema = {
       },
     },
     'meta-data': {
-      type: ['object'],
+      type: ['object', 'boolean'],
       properties: {
         title: {
           type: 'string',

--- a/frontend/config-assistant/src/helpers/schema/mergeAllOfs.ts
+++ b/frontend/config-assistant/src/helpers/schema/mergeAllOfs.ts
@@ -14,15 +14,8 @@ export function mergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType 
 
 export function safeMergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType | false {
   try {
-    return mergeAllOf(schema, {
-      deep: false,
-      resolvers: {
-        defaultResolver: mergeAllOf.options.resolvers.title,
-        // add additional resolvers here, most of the keywords are NOT supported by default
-      },
-    });
+    return mergeAllOfs(schema);
   } catch (e) {
-    console.log('Cannot merge allOfs for ', schema);
     return false;
   }
 }

--- a/frontend/config-assistant/src/helpers/schema/mergeAllOfs.ts
+++ b/frontend/config-assistant/src/helpers/schema/mergeAllOfs.ts
@@ -3,6 +3,7 @@ import type {JsonSchemaObjectType} from '@/model/JsonSchemaType';
 import mergeAllOf from 'json-schema-merge-allof';
 
 export function mergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType {
+  console.log('merge allOfs for ', schema);
   return mergeAllOf(schema, {
     deep: false,
     resolvers: {
@@ -10,4 +11,20 @@ export function mergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType 
       // add additional resolvers here, most of the keywords are NOT supported by default
     },
   });
+}
+
+export function safeMergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType | false {
+  console.log('merge allOfs for ', schema);
+  try {
+    return mergeAllOf(schema, {
+      deep: false,
+      resolvers: {
+        defaultResolver: mergeAllOf.options.resolvers.title,
+        // add additional resolvers here, most of the keywords are NOT supported by default
+      },
+    });
+  } catch (e) {
+    console.log('Cannot merge allOfs for ', schema);
+    return false;
+  }
 }

--- a/frontend/config-assistant/src/helpers/schema/mergeAllOfs.ts
+++ b/frontend/config-assistant/src/helpers/schema/mergeAllOfs.ts
@@ -3,7 +3,6 @@ import type {JsonSchemaObjectType} from '@/model/JsonSchemaType';
 import mergeAllOf from 'json-schema-merge-allof';
 
 export function mergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType {
-  console.log('merge allOfs for ', schema);
   return mergeAllOf(schema, {
     deep: false,
     resolvers: {
@@ -14,7 +13,6 @@ export function mergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType 
 }
 
 export function safeMergeAllOfs(schema: JsonSchemaObjectType): JsonSchemaObjectType | false {
-  console.log('merge allOfs for ', schema);
   try {
     return mergeAllOf(schema, {
       deep: false,

--- a/frontend/config-assistant/src/helpers/schema/schemaPreprocessor.ts
+++ b/frontend/config-assistant/src/helpers/schema/schemaPreprocessor.ts
@@ -14,8 +14,11 @@ const preprocessedRefSchemas: Map<string, JsonSchemaObjectType> = new Map();
  * Preprocesses the schema:
  * - Resolves references (lazy resolver)
  * - Merges all-ofs
- * - For all oneOfs and anyOfs: copies the property schema into the sub-schemas
- * - Induce title for schema if it does not have title defined
+ * - Converts list of types to oneOfs
+ * - Removes oneOfs and anyOfs not compatible with schema
+ * - Merges back oneOfs and anyOfs with just one single entry into the schema
+ * - If it is possible: merges oneOfs into anyOfs
+ * - Induces title for schema if it does not have title defined
  * - Converts const to enum
  * - Injects types of enum to types property
  *

--- a/frontend/config-assistant/src/helpers/schema/schemaPreprocessor.ts
+++ b/frontend/config-assistant/src/helpers/schema/schemaPreprocessor.ts
@@ -1,4 +1,8 @@
-import type {JsonSchemaObjectType, SchemaPropertyType} from '@/model/JsonSchemaType';
+import type {
+  JsonSchemaObjectType,
+  JsonSchemaType,
+  SchemaPropertyType,
+} from '@/model/JsonSchemaType';
 import pointer from 'json-pointer';
 import {useSessionStore} from '@/store/sessionStore';
 import {nonBooleanSchema} from '@/helpers/schema/SchemaUtils';
@@ -7,7 +11,13 @@ import {mergeAllOfs} from '@/helpers/schema/mergeAllOfs';
 const preprocessedRefSchemas: Map<string, JsonSchemaObjectType> = new Map();
 
 /**
- * Preprocesses the schema.
+ * Preprocesses the schema:
+ * - Resolves references (lazy resolver)
+ * - Merges all-ofs
+ * - For all oneOfs and anyOfs: copies the property schema into the sub-schemas
+ * - Induce title for schema if it does not have title defined
+ * - Converts const to enum
+ * - Injects types of enum to types property
  *
  * @param schema the schema to preprocess
  * @returns the preprocessed schema
@@ -20,41 +30,15 @@ export function preprocessSchema(schema: JsonSchemaObjectType): JsonSchemaObject
 
   if (hasAllOfs(copiedSchema)) {
     // @ts-ignore
-    copiedSchema.allOf = copiedSchema.allOf!!.map(subSchema =>
-      preprocessSchema(subSchema as JsonSchemaObjectType)
-    );
+    copiedSchema.allOf = copiedSchema.allOf!!.map(subSchema => {
+      return preprocessSchema(subSchema as JsonSchemaObjectType);
+    });
     copiedSchema = mergeAllOfs(copiedSchema as JsonSchemaObjectType);
   }
 
-  if (hasOneOfs(copiedSchema)) {
-    // @ts-ignore
-    copiedSchema.oneOf = copiedSchema.oneOf!!.map(subSchema => {
-      const copiedSchemaWithoutOneOf = {...copiedSchema};
-      delete copiedSchemaWithoutOneOf.oneOf;
-      delete copiedSchemaWithoutOneOf.title;
-      delete copiedSchemaWithoutOneOf.description;
-      const resultSchema = {
-        allOf: [preprocessSchema(subSchema as JsonSchemaObjectType), copiedSchemaWithoutOneOf],
-      };
-      return mergeAllOfs(resultSchema as JsonSchemaObjectType);
-    });
-  }
-
-  if (hasAnyOfs(copiedSchema)) {
-    // @ts-ignore
-    copiedSchema.anyOf = copiedSchema.anyOf!!.map(subSchema => {
-      const copiedSchemaWithoutAnyOf = {...copiedSchema};
-      delete copiedSchemaWithoutAnyOf.anyOf;
-      delete copiedSchemaWithoutAnyOf.title;
-      delete copiedSchemaWithoutAnyOf.description;
-      const resultSchema = {
-        allOf: [preprocessSchema(subSchema as JsonSchemaObjectType), copiedSchemaWithoutAnyOf],
-      };
-      return mergeAllOfs(resultSchema as JsonSchemaObjectType);
-    });
-  }
-
-  optimizeSchema(copiedSchema);
+  convertTypesToOneOf(copiedSchema);
+  preprocessOneOfs(copiedSchema);
+  preprocessAnyOfs(copiedSchema);
 
   induceTitles(copiedSchema);
 
@@ -66,6 +50,86 @@ export function preprocessSchema(schema: JsonSchemaObjectType): JsonSchemaObject
 
 function hasRef(schema: JsonSchemaObjectType): boolean {
   return schema.$ref !== undefined;
+}
+
+function convertTypesToOneOf(schema: JsonSchemaObjectType) {
+  if (!Array.isArray(schema.type)) {
+    return;
+  }
+
+  if (schema.type.length == 1) {
+    schema.type = schema.type[0];
+    return;
+  }
+
+  // easier scenario: no oneOfs
+  if (!hasOneOfs(schema)) {
+    let newOneOfs: JsonSchemaType[] = [];
+
+    schema.type.forEach(propertyType => {
+      const typeSchema = {
+        type: propertyType,
+      };
+
+      newOneOfs.push(typeSchema);
+    });
+
+    schema.oneOf = newOneOfs;
+    delete schema.type;
+  } else {
+    // more difficult scenario: oneOfs exist. Multiply original oneOfs with types
+    let newOneOfs: JsonSchemaType[] = [];
+    schema.type.forEach(propertyType => {
+      const typeSchema = {
+        type: propertyType,
+      };
+
+      schema.oneOf!.forEach((originalOneOf: JsonSchemaType) => {
+        console.log('for originalOneOf ', originalOneOf);
+
+        // TODO: handle case where OneOfs already have one or more types
+        const combinedSchema = {
+          allOf: [typeSchema, originalOneOf],
+        };
+        const newOneOf = mergeAllOfs(combinedSchema);
+        newOneOfs.push(newOneOf);
+      });
+    });
+    schema.oneOf = newOneOfs;
+    delete schema.type;
+  }
+}
+
+function preprocessAnyOfs(schema: JsonSchemaObjectType) {
+  if (hasAnyOfs(schema)) {
+    // @ts-ignore
+    schema.anyOf = schema.anyOf!!.map(subSchema => {
+      const copiedSchemaWithoutAnyOf = {...schema};
+      delete copiedSchemaWithoutAnyOf.anyOf;
+      delete copiedSchemaWithoutAnyOf.title;
+      delete copiedSchemaWithoutAnyOf.description;
+      const resultSchema = {
+        allOf: [preprocessSchema(subSchema as JsonSchemaObjectType), copiedSchemaWithoutAnyOf],
+      };
+      return mergeAllOfs(resultSchema as JsonSchemaObjectType);
+    });
+  }
+}
+
+function preprocessOneOfs(schema: JsonSchemaObjectType) {
+  if (hasOneOfs(schema)) {
+    // @ts-ignore
+    schema.oneOf = schema.oneOf!!.map(subSchema => {
+      const copiedSchemaWithoutOneOf = {...schema};
+      delete copiedSchemaWithoutOneOf.oneOf;
+      delete copiedSchemaWithoutOneOf.title;
+      delete copiedSchemaWithoutOneOf.description;
+      const resultSchema = {
+        allOf: [preprocessSchema(subSchema as JsonSchemaObjectType), copiedSchemaWithoutOneOf],
+      };
+      return mergeAllOfs(resultSchema as JsonSchemaObjectType);
+    });
+  }
 }
 
 function resolveReference(copiedSchema: JsonSchemaObjectType) {
@@ -98,12 +162,6 @@ function hasOneOfs(schema: JsonSchemaObjectType): boolean {
 }
 function hasAnyOfs(schema: JsonSchemaObjectType): boolean {
   return schema.anyOf !== undefined && schema.anyOf.length > 0;
-}
-
-function optimizeSchema(schema: JsonSchemaObjectType) {
-  if (hasOneOfs(schema)) {
-    // TODO: if it is just oneOf of types, then replace it by a choice of types
-  }
 }
 
 function induceTitles(schema: JsonSchemaObjectType): void {

--- a/frontend/config-assistant/src/helpers/schema/schemaPreprocessor.ts
+++ b/frontend/config-assistant/src/helpers/schema/schemaPreprocessor.ts
@@ -30,9 +30,9 @@ export function preprocessSchema(schema: JsonSchemaObjectType): JsonSchemaObject
 
   if (hasAllOfs(copiedSchema)) {
     // @ts-ignore
-    copiedSchema.allOf = copiedSchema.allOf!!.map(subSchema => {
-      return preprocessSchema(subSchema as JsonSchemaObjectType);
-    });
+    copiedSchema.allOf = copiedSchema.allOf!!.map(subSchema =>
+      preprocessSchema(subSchema as JsonSchemaObjectType)
+    );
     copiedSchema = mergeAllOfs(copiedSchema as JsonSchemaObjectType);
   }
 
@@ -85,8 +85,6 @@ function convertTypesToOneOf(schema: JsonSchemaObjectType) {
       };
 
       schema.oneOf!.forEach((originalOneOf: JsonSchemaType) => {
-        console.log('for originalOneOf ', originalOneOf);
-
         // TODO: handle case where OneOfs already have one or more types
         const combinedSchema = {
           allOf: [typeSchema, originalOneOf],

--- a/frontend/config-assistant/src/model/OneOfAnyOfSelectionOption.ts
+++ b/frontend/config-assistant/src/model/OneOfAnyOfSelectionOption.ts
@@ -21,6 +21,8 @@ export function schemaOptionToString(schema: JsonSchema, index: number): string 
     result += ': ' + schema.title;
   } else if (schema.description) {
     result += ': ' + schema.description;
+  } else if (schema.type) {
+    result += ': ' + schema.type;
   }
 
   return result;


### PR DESCRIPTION
WIP

ToDo: in oneOf dropdown menu, show the name of the types (by adding types to the title inducing functionality in preprocessor).

Note: mergeAllOf seems to have problems with properties that have both the boolean and the object type.
Until we enhance mergeAllOf, I have removed support for schemas that are only a boolean for now.