### PR TITLE
fix cursor pointer and style of add item button

### DIFF
--- a/frontend/config-assistant/src/components/gui-editor/PropertiesPanel.vue
+++ b/frontend/config-assistant/src/components/gui-editor/PropertiesPanel.vue
@@ -475,7 +475,6 @@ function zoomIntoPath(path: Path) {
     scrollable
     scroll-direction="vertical"
     scroll-height="flex"
-    row-hover
     :lazy="true"
     :loading="loadingDebounced"
     v-model:expandedKeys="useSessionStore().currentExpandedElements"
@@ -519,11 +518,12 @@ function zoomIntoPath(path: Path) {
         <!-- special tree nodes -->
         <span
           v-if="slotProps.node.type === TreeNodeType.ADD_ITEM"
+          class="cursor-pointer"
           style="width: 100%; min-width: 50%"
           :style="addNegativeMarginForTableStyle(slotProps.node.data.depth)"
           @click="addEmptyArrayEntry(slotProps.node.data.relativePath)"
           @keyup.enter="addEmptyArrayEntry(slotProps.node.data.relativePath)">
-          <Button text severity="secondary" class="text-gray-500" style="margin-left: -0.75rem">
+          <Button text severity="secondary" class="text-gray-500" style="margin-left: -1.5rem">
             <i class="pi pi-plus" />
             <span class="pl-2">Add item</span>
           </Button>
@@ -532,6 +532,7 @@ function zoomIntoPath(path: Path) {
         <span
           v-if="slotProps.node.type === TreeNodeType.ADD_PROPERTY"
           style="width: 100%; min-width: 50%"
+          class="cursor-pointer"
           :style="addNegativeMarginForTableStyle(slotProps.node.data.depth)"
           @click="
             addEmptyProperty(slotProps.node.data.relativePath, slotProps.node.data.absolutePath)

--- a/frontend/config-assistant/src/components/gui-editor/PropertyMetadata.vue
+++ b/frontend/config-assistant/src/components/gui-editor/PropertyMetadata.vue
@@ -151,7 +151,7 @@ function isInvalid(): boolean {
   <span class="flex flex-row w-full items-center">
     <span
       class="mr-2"
-      :class="{'hover:underline': canZoomIn(), 'bg-yellow-100': highlighted}"
+      :class="{'hover:underline cursor-pointer': canZoomIn(), 'bg-yellow-100': highlighted}"
       :tabindex="canZoomIn() ? 0 : -1"
       @click="
         isPropertyNameEditable()


### PR DESCRIPTION
Fix cursor not being a pointer all over the tree table, but only on clickable links and the add item/property rows